### PR TITLE
Fixup ownership of the /tmp/downloads directory

### DIFF
--- a/generated/5.0/standalone/Dockerfile
+++ b/generated/5.0/standalone/Dockerfile
@@ -55,7 +55,7 @@ EXPOSE 5672 15672
 COPY entry.sh /usr/bin/mq-entry.sh
 
 # make the temp dir for all the downloads
-RUN mkdir -p /tmp/downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # create volumes by default
 VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 

--- a/generated/5.0/unit/Dockerfile
+++ b/generated/5.0/unit/Dockerfile
@@ -18,14 +18,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y libmysqlclient2
 
 # expose the ports for mailerq. note that this doesn't really 'expose' them but is more
 # of a general hint towards the ports that will likely be used, for documentation purposes.
-EXPOSE 25 80 443 
+EXPOSE 25 80 443
 
-# make the temp dir for all the downloads, these are ephemeral so may die with the container.
-RUN mkdir -p /tmp/downloads
+# make the temp dir for all the downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # we do not want the default config file to be present, because there is no local rabbitmq and we want this
 # file to be bound as well as the logfiles.
-VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 
+VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"]
 
 # bootstrap our entry point and the command to run
 CMD rm -f /tmp/mailerq.pid && mailerq --lock=/tmp/mailerq.pid

--- a/generated/5.1/standalone/Dockerfile
+++ b/generated/5.1/standalone/Dockerfile
@@ -55,7 +55,7 @@ EXPOSE 5672 15672
 COPY entry.sh /usr/bin/mq-entry.sh
 
 # make the temp dir for all the downloads
-RUN mkdir -p /tmp/downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # create volumes by default
 VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 

--- a/generated/5.1/unit/Dockerfile
+++ b/generated/5.1/unit/Dockerfile
@@ -18,14 +18,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y libmysqlclient2
 
 # expose the ports for mailerq. note that this doesn't really 'expose' them but is more
 # of a general hint towards the ports that will likely be used, for documentation purposes.
-EXPOSE 25 80 443 
+EXPOSE 25 80 443
 
-# make the temp dir for all the downloads, these are ephemeral so may die with the container.
-RUN mkdir -p /tmp/downloads
+# make the temp dir for all the downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # we do not want the default config file to be present, because there is no local rabbitmq and we want this
 # file to be bound as well as the logfiles.
-VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 
+VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"]
 
 # bootstrap our entry point and the command to run
 CMD rm -f /tmp/mailerq.pid && mailerq --lock=/tmp/mailerq.pid

--- a/generated/5.10/standalone/Dockerfile
+++ b/generated/5.10/standalone/Dockerfile
@@ -55,7 +55,7 @@ EXPOSE 5672 15672
 COPY entry.sh /usr/bin/mq-entry.sh
 
 # make the temp dir for all the downloads
-RUN mkdir -p /tmp/downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # create volumes by default
 VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 

--- a/generated/5.10/unit/Dockerfile
+++ b/generated/5.10/unit/Dockerfile
@@ -18,14 +18,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y libmysqlclient2
 
 # expose the ports for mailerq. note that this doesn't really 'expose' them but is more
 # of a general hint towards the ports that will likely be used, for documentation purposes.
-EXPOSE 25 80 443 
+EXPOSE 25 80 443
 
-# make the temp dir for all the downloads, these are ephemeral so may die with the container.
-RUN mkdir -p /tmp/downloads
+# make the temp dir for all the downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # we do not want the default config file to be present, because there is no local rabbitmq and we want this
 # file to be bound as well as the logfiles.
-VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 
+VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"]
 
 # bootstrap our entry point and the command to run
 CMD rm -f /tmp/mailerq.pid && mailerq --lock=/tmp/mailerq.pid

--- a/generated/5.11/standalone/Dockerfile
+++ b/generated/5.11/standalone/Dockerfile
@@ -55,7 +55,7 @@ EXPOSE 5672 15672
 COPY entry.sh /usr/bin/mq-entry.sh
 
 # make the temp dir for all the downloads
-RUN mkdir -p /tmp/downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # create volumes by default
 VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 

--- a/generated/5.11/unit/Dockerfile
+++ b/generated/5.11/unit/Dockerfile
@@ -18,14 +18,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y libmysqlclient2
 
 # expose the ports for mailerq. note that this doesn't really 'expose' them but is more
 # of a general hint towards the ports that will likely be used, for documentation purposes.
-EXPOSE 25 80 443 
+EXPOSE 25 80 443
 
-# make the temp dir for all the downloads, these are ephemeral so may die with the container.
-RUN mkdir -p /tmp/downloads
+# make the temp dir for all the downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # we do not want the default config file to be present, because there is no local rabbitmq and we want this
 # file to be bound as well as the logfiles.
-VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 
+VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"]
 
 # bootstrap our entry point and the command to run
 CMD rm -f /tmp/mailerq.pid && mailerq --lock=/tmp/mailerq.pid

--- a/generated/5.12/standalone/Dockerfile
+++ b/generated/5.12/standalone/Dockerfile
@@ -55,7 +55,7 @@ EXPOSE 5672 15672
 COPY entry.sh /usr/bin/mq-entry.sh
 
 # make the temp dir for all the downloads
-RUN mkdir -p /tmp/downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # create volumes by default
 VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 

--- a/generated/5.12/unit/Dockerfile
+++ b/generated/5.12/unit/Dockerfile
@@ -18,14 +18,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y libmysqlclient2
 
 # expose the ports for mailerq. note that this doesn't really 'expose' them but is more
 # of a general hint towards the ports that will likely be used, for documentation purposes.
-EXPOSE 25 80 443 
+EXPOSE 25 80 443
 
-# make the temp dir for all the downloads, these are ephemeral so may die with the container.
-RUN mkdir -p /tmp/downloads
+# make the temp dir for all the downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # we do not want the default config file to be present, because there is no local rabbitmq and we want this
 # file to be bound as well as the logfiles.
-VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 
+VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"]
 
 # bootstrap our entry point and the command to run
 CMD rm -f /tmp/mailerq.pid && mailerq --lock=/tmp/mailerq.pid

--- a/generated/5.13/standalone/Dockerfile
+++ b/generated/5.13/standalone/Dockerfile
@@ -55,7 +55,7 @@ EXPOSE 5672 15672
 COPY entry.sh /usr/bin/mq-entry.sh
 
 # make the temp dir for all the downloads
-RUN mkdir -p /tmp/downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # create volumes by default
 VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 

--- a/generated/5.13/unit/Dockerfile
+++ b/generated/5.13/unit/Dockerfile
@@ -18,14 +18,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y libmysqlclient2
 
 # expose the ports for mailerq. note that this doesn't really 'expose' them but is more
 # of a general hint towards the ports that will likely be used, for documentation purposes.
-EXPOSE 25 80 443 
+EXPOSE 25 80 443
 
-# make the temp dir for all the downloads, these are ephemeral so may die with the container.
-RUN mkdir -p /tmp/downloads
+# make the temp dir for all the downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # we do not want the default config file to be present, because there is no local rabbitmq and we want this
 # file to be bound as well as the logfiles.
-VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 
+VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"]
 
 # bootstrap our entry point and the command to run
 CMD rm -f /tmp/mailerq.pid && mailerq --lock=/tmp/mailerq.pid

--- a/generated/5.2/standalone/Dockerfile
+++ b/generated/5.2/standalone/Dockerfile
@@ -55,7 +55,7 @@ EXPOSE 5672 15672
 COPY entry.sh /usr/bin/mq-entry.sh
 
 # make the temp dir for all the downloads
-RUN mkdir -p /tmp/downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # create volumes by default
 VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 

--- a/generated/5.2/unit/Dockerfile
+++ b/generated/5.2/unit/Dockerfile
@@ -18,14 +18,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y libmysqlclient2
 
 # expose the ports for mailerq. note that this doesn't really 'expose' them but is more
 # of a general hint towards the ports that will likely be used, for documentation purposes.
-EXPOSE 25 80 443 
+EXPOSE 25 80 443
 
-# make the temp dir for all the downloads, these are ephemeral so may die with the container.
-RUN mkdir -p /tmp/downloads
+# make the temp dir for all the downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # we do not want the default config file to be present, because there is no local rabbitmq and we want this
 # file to be bound as well as the logfiles.
-VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 
+VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"]
 
 # bootstrap our entry point and the command to run
 CMD rm -f /tmp/mailerq.pid && mailerq --lock=/tmp/mailerq.pid

--- a/generated/5.3/standalone/Dockerfile
+++ b/generated/5.3/standalone/Dockerfile
@@ -55,7 +55,7 @@ EXPOSE 5672 15672
 COPY entry.sh /usr/bin/mq-entry.sh
 
 # make the temp dir for all the downloads
-RUN mkdir -p /tmp/downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # create volumes by default
 VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 

--- a/generated/5.3/unit/Dockerfile
+++ b/generated/5.3/unit/Dockerfile
@@ -18,14 +18,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y libmysqlclient2
 
 # expose the ports for mailerq. note that this doesn't really 'expose' them but is more
 # of a general hint towards the ports that will likely be used, for documentation purposes.
-EXPOSE 25 80 443 
+EXPOSE 25 80 443
 
-# make the temp dir for all the downloads, these are ephemeral so may die with the container.
-RUN mkdir -p /tmp/downloads
+# make the temp dir for all the downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # we do not want the default config file to be present, because there is no local rabbitmq and we want this
 # file to be bound as well as the logfiles.
-VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 
+VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"]
 
 # bootstrap our entry point and the command to run
 CMD rm -f /tmp/mailerq.pid && mailerq --lock=/tmp/mailerq.pid

--- a/generated/5.4/standalone/Dockerfile
+++ b/generated/5.4/standalone/Dockerfile
@@ -55,7 +55,7 @@ EXPOSE 5672 15672
 COPY entry.sh /usr/bin/mq-entry.sh
 
 # make the temp dir for all the downloads
-RUN mkdir -p /tmp/downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # create volumes by default
 VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 

--- a/generated/5.4/unit/Dockerfile
+++ b/generated/5.4/unit/Dockerfile
@@ -18,14 +18,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y libmysqlclient2
 
 # expose the ports for mailerq. note that this doesn't really 'expose' them but is more
 # of a general hint towards the ports that will likely be used, for documentation purposes.
-EXPOSE 25 80 443 
+EXPOSE 25 80 443
 
-# make the temp dir for all the downloads, these are ephemeral so may die with the container.
-RUN mkdir -p /tmp/downloads
+# make the temp dir for all the downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # we do not want the default config file to be present, because there is no local rabbitmq and we want this
 # file to be bound as well as the logfiles.
-VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 
+VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"]
 
 # bootstrap our entry point and the command to run
 CMD rm -f /tmp/mailerq.pid && mailerq --lock=/tmp/mailerq.pid

--- a/generated/5.5/standalone/Dockerfile
+++ b/generated/5.5/standalone/Dockerfile
@@ -55,7 +55,7 @@ EXPOSE 5672 15672
 COPY entry.sh /usr/bin/mq-entry.sh
 
 # make the temp dir for all the downloads
-RUN mkdir -p /tmp/downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # create volumes by default
 VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 

--- a/generated/5.5/unit/Dockerfile
+++ b/generated/5.5/unit/Dockerfile
@@ -18,14 +18,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y libmysqlclient2
 
 # expose the ports for mailerq. note that this doesn't really 'expose' them but is more
 # of a general hint towards the ports that will likely be used, for documentation purposes.
-EXPOSE 25 80 443 
+EXPOSE 25 80 443
 
-# make the temp dir for all the downloads, these are ephemeral so may die with the container.
-RUN mkdir -p /tmp/downloads
+# make the temp dir for all the downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # we do not want the default config file to be present, because there is no local rabbitmq and we want this
 # file to be bound as well as the logfiles.
-VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 
+VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"]
 
 # bootstrap our entry point and the command to run
 CMD rm -f /tmp/mailerq.pid && mailerq --lock=/tmp/mailerq.pid

--- a/generated/5.6/standalone/Dockerfile
+++ b/generated/5.6/standalone/Dockerfile
@@ -55,7 +55,7 @@ EXPOSE 5672 15672
 COPY entry.sh /usr/bin/mq-entry.sh
 
 # make the temp dir for all the downloads
-RUN mkdir -p /tmp/downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # create volumes by default
 VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 

--- a/generated/5.6/unit/Dockerfile
+++ b/generated/5.6/unit/Dockerfile
@@ -18,14 +18,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y libmysqlclient2
 
 # expose the ports for mailerq. note that this doesn't really 'expose' them but is more
 # of a general hint towards the ports that will likely be used, for documentation purposes.
-EXPOSE 25 80 443 
+EXPOSE 25 80 443
 
-# make the temp dir for all the downloads, these are ephemeral so may die with the container.
-RUN mkdir -p /tmp/downloads
+# make the temp dir for all the downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # we do not want the default config file to be present, because there is no local rabbitmq and we want this
 # file to be bound as well as the logfiles.
-VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 
+VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"]
 
 # bootstrap our entry point and the command to run
 CMD rm -f /tmp/mailerq.pid && mailerq --lock=/tmp/mailerq.pid

--- a/generated/5.7/standalone/Dockerfile
+++ b/generated/5.7/standalone/Dockerfile
@@ -55,7 +55,7 @@ EXPOSE 5672 15672
 COPY entry.sh /usr/bin/mq-entry.sh
 
 # make the temp dir for all the downloads
-RUN mkdir -p /tmp/downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # create volumes by default
 VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 

--- a/generated/5.7/unit/Dockerfile
+++ b/generated/5.7/unit/Dockerfile
@@ -18,14 +18,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y libmysqlclient2
 
 # expose the ports for mailerq. note that this doesn't really 'expose' them but is more
 # of a general hint towards the ports that will likely be used, for documentation purposes.
-EXPOSE 25 80 443 
+EXPOSE 25 80 443
 
-# make the temp dir for all the downloads, these are ephemeral so may die with the container.
-RUN mkdir -p /tmp/downloads
+# make the temp dir for all the downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # we do not want the default config file to be present, because there is no local rabbitmq and we want this
 # file to be bound as well as the logfiles.
-VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 
+VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"]
 
 # bootstrap our entry point and the command to run
 CMD rm -f /tmp/mailerq.pid && mailerq --lock=/tmp/mailerq.pid

--- a/generated/5.8/standalone/Dockerfile
+++ b/generated/5.8/standalone/Dockerfile
@@ -55,7 +55,7 @@ EXPOSE 5672 15672
 COPY entry.sh /usr/bin/mq-entry.sh
 
 # make the temp dir for all the downloads
-RUN mkdir -p /tmp/downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # create volumes by default
 VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 

--- a/generated/5.8/unit/Dockerfile
+++ b/generated/5.8/unit/Dockerfile
@@ -18,14 +18,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y libmysqlclient2
 
 # expose the ports for mailerq. note that this doesn't really 'expose' them but is more
 # of a general hint towards the ports that will likely be used, for documentation purposes.
-EXPOSE 25 80 443 
+EXPOSE 25 80 443
 
-# make the temp dir for all the downloads, these are ephemeral so may die with the container.
-RUN mkdir -p /tmp/downloads
+# make the temp dir for all the downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # we do not want the default config file to be present, because there is no local rabbitmq and we want this
 # file to be bound as well as the logfiles.
-VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 
+VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"]
 
 # bootstrap our entry point and the command to run
 CMD rm -f /tmp/mailerq.pid && mailerq --lock=/tmp/mailerq.pid

--- a/generated/5.9/standalone/Dockerfile
+++ b/generated/5.9/standalone/Dockerfile
@@ -55,7 +55,7 @@ EXPOSE 5672 15672
 COPY entry.sh /usr/bin/mq-entry.sh
 
 # make the temp dir for all the downloads
-RUN mkdir -p /tmp/downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # create volumes by default
 VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 

--- a/generated/5.9/unit/Dockerfile
+++ b/generated/5.9/unit/Dockerfile
@@ -18,14 +18,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y libmysqlclient2
 
 # expose the ports for mailerq. note that this doesn't really 'expose' them but is more
 # of a general hint towards the ports that will likely be used, for documentation purposes.
-EXPOSE 25 80 443 
+EXPOSE 25 80 443
 
-# make the temp dir for all the downloads, these are ephemeral so may die with the container.
-RUN mkdir -p /tmp/downloads
+# make the temp dir for all the downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # we do not want the default config file to be present, because there is no local rabbitmq and we want this
 # file to be bound as well as the logfiles.
-VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 
+VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"]
 
 # bootstrap our entry point and the command to run
 CMD rm -f /tmp/mailerq.pid && mailerq --lock=/tmp/mailerq.pid

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -55,7 +55,7 @@ EXPOSE 5672 15672
 COPY entry.sh /usr/bin/mq-entry.sh
 
 # make the temp dir for all the downloads
-RUN mkdir -p /tmp/downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # create volumes by default
 VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 

--- a/unit/Dockerfile
+++ b/unit/Dockerfile
@@ -18,14 +18,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y libmysqlclient2
 
 # expose the ports for mailerq. note that this doesn't really 'expose' them but is more
 # of a general hint towards the ports that will likely be used, for documentation purposes.
-EXPOSE 25 80 443 
+EXPOSE 25 80 443
 
-# make the temp dir for all the downloads, these are ephemeral so may die with the container.
-RUN mkdir -p /tmp/downloads
+# make the temp dir for all the downloads
+RUN mkdir -p /tmp/downloads && chown mailerq:mailerq /tmp/downloads
 
 # we do not want the default config file to be present, because there is no local rabbitmq and we want this
 # file to be bound as well as the logfiles.
-VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"] 
+VOLUME ["/etc/mailerq", "/var/log/mailerq", "/tmp/downloads"]
 
 # bootstrap our entry point and the command to run
 CMD rm -f /tmp/mailerq.pid && mailerq --lock=/tmp/mailerq.pid


### PR DESCRIPTION
It should be owned by the user that is set in the config file now.

It is actually possible to set a different user in the config file,
by means of using `docker run -v /etc/mailerq:/etc/mailerq`, as that
will cause the mailerq process in the docker container to use the
local config file. But in any case, this fixes it for the case that
the user is the default `mailerq` user.

Aside: I don't know whether generating all these Dockerfiles for
past releases is a good idea. Previous versions did not care about
user rights of the /tmp/downloads folder, or may even expect it to be
owned by the `root` user.